### PR TITLE
Replace deprecated request-promise package with bent

### DIFF
--- a/bin/juji-chat
+++ b/bin/juji-chat
@@ -45,7 +45,8 @@ if (!program.firstName) {
 var chatInfo;
 var ws;
 
-const request = require('request-promise'),
+// https://github.com/mikeal/bent same author as deprecated request-promise
+const bent = require('bent'),
       util = require('util'),
       color = require("colors"),
       readline = require('readline'),
@@ -75,11 +76,11 @@ const chatFormat = `
                     }
                 }
                 `;
-rl.on('line', (line) => {
+    rl.on('line', (line) => {
     ws.send(util.format(chatFormat, chatInfo.participationId, line));
 });
 
-rl.on('SIGINT', () => {
+    rl.on('SIGINT', () => {
     rl.question('Are you sure you want to exit? ', (answer) => {
         if (answer.match(/^y(es)?$/i)) {
             rl.close();
@@ -93,14 +94,21 @@ async function startChat() {
     //
     // step 1: obtain chat information
     //
-    const options =  {
-        method: 'POST',
-        url: url,
-        formData: {
-            firstName: program.firstName
-        }
-    };
-    const response = await request(options);
+
+    var FormData = require('form-data');
+    var form = new FormData();
+    form.append('firstName', program.firstName);
+
+    const postJSON = bent('POST', 'string', { 'Content-Type': 'multipart/form-data'});
+    //const postJSON = bent('POST', 'buffer', { 'Content-Type': 'multipart/form-data'});
+
+    const response = await postJSON(url, form, form.getHeaders());
+
+    // console.log(response);
+    // Example chatInfo =
+    // {"chatUrl":"https://juji.ai/chat/67460ae2-a468-4169-a95d-92e4a8aba110",
+    //  "participationId":"67460ae2-a468-4169-a95d-92e4a8aba110",
+    //  "websocketUrl":"wss://juji.ai/api/v1/ws"}
     chatInfo = JSON.parse(response);
 
     //
@@ -175,7 +183,7 @@ async function startChat() {
                                     console_out('[Choice] text: ' + c.text + '; value: ' + c.value);
                                 })
                             }
-                            
+
                         })
                     }
                     if (message.quickReply){

--- a/bin/juji-chat
+++ b/bin/juji-chat
@@ -45,7 +45,8 @@ if (!program.firstName) {
 var chatInfo;
 var ws;
 
-const request = require('request-promise'),
+// https://github.com/mikeal/bent same author as deprecated request-promise
+const bent = require('bent'),
       util = require('util'),
       color = require("colors"),
       readline = require('readline'),
@@ -75,11 +76,11 @@ const chatFormat = `
                     }
                 }
                 `;
-rl.on('line', (line) => {
+    rl.on('line', (line) => {
     ws.send(util.format(chatFormat, chatInfo.participationId, line));
 });
 
-rl.on('SIGINT', () => {
+    rl.on('SIGINT', () => {
     rl.question('Are you sure you want to exit? ', (answer) => {
         if (answer.match(/^y(es)?$/i)) {
             rl.close();
@@ -93,14 +94,21 @@ async function startChat() {
     //
     // step 1: obtain chat information
     //
-    const options =  {
-        method: 'POST',
-        url: url,
-        formData: {
-            firstName: program.firstName
-        }
-    };
-    const response = await request(options);
+
+    var FormData = require('form-data');
+    var form = new FormData();
+    form.append('firstName', program.firstName);
+
+    const postJSON = bent('POST', 'string', { 'Content-Type': 'multipart/form-data'});
+    //const postJSON = bent('POST', 'buffer', { 'Content-Type': 'multipart/form-data'});
+
+    const response = await postJSON(url, form, form.getHeaders());
+
+    console.log(response);
+    // Example chatInfo =
+    // {"chatUrl":"https://juji.ai/chat/67460ae2-a468-4169-a95d-92e4a8aba110",
+    //  "participationId":"67460ae2-a468-4169-a95d-92e4a8aba110",
+    //  "websocketUrl":"wss://juji.ai/api/v1/ws"}
     chatInfo = JSON.parse(response);
 
     //
@@ -175,7 +183,7 @@ async function startChat() {
                                     console_out('[Choice] text: ' + c.text + '; value: ' + c.value);
                                 })
                             }
-                            
+
                         })
                     }
                     if (message.quickReply){

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
         "minimist": ">=1.2.2"
     },
     "dependencies": {
+        "bent": "^7.3.12",
         "colors": "^1.4.0",
         "commander": "^6.2.0",
+        "form-data": "^4.0.1",
         "graphql": "^15.8.0",
         "graphql-request": "^3.3.0",
         "isomorphic-ws": "^4.0.1",
         "minimist": ">=1.2.5",
         "preferences": "^2.0.2",
-        "request": "^2.88.0",
-        "request-promise": "^4.2.4",
         "ws": "^7.4.0"
     },
     "repository": {


### PR DESCRIPTION
Packages request and request-promise have been deprecated and have 2 un-resolvable security vulnerabilities; see console errors below. Migrated the code to use a newer package call "bent" by the same author.

bin/juji-chat -f Da https://juji.ai/pre-chat/6723f762-43fd-49e4-8a7e-d20127043424?mode=test
node:internal/modules/cjs/loader:502
      throw err;
      ^

Error: Cannot find module '/home/dlyeh/github.com/juji-io/cli-client/node_modules/request-promise/lib/tp.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:494:19)
    at Function._findPath (node:internal/modules/cjs/loader:795:18)
    at Function._resolveFilename (node:internal/modules/cjs/loader:1235:27)
    at Function._load (node:internal/modules/cjs/loader:1075:27)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Module.require (node:internal/modules/cjs/loader:1340:12)
    at require (node:internal/modules/helpers:141:16)
    at Object.<anonymous> (/home/dlyeh/github.com/juji-io/cli-client/bin/juji-chat:48:17)
    at Module._compile (node:internal/modules/cjs/loader:1546:14) {
  code: 'MODULE_NOT_FOUND',
  path: '/home/dlyeh/github.com/juji-io/cli-client/node_modules/request-promise/package.json',
  requestPath: 'request-promise'
}

Node.js v22.11.0

npm i request-promise

up to date, audited 293 packages in 3s

27 packages are looking for funding
  run `npm fund` for details

2 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.